### PR TITLE
chore: get the whole URL as input

### DIFF
--- a/.github/workflows/update-token.yml
+++ b/.github/workflows/update-token.yml
@@ -21,12 +21,12 @@ jobs:
             <head>
               <meta charset="utf-8">
               <title>Redirect a Slack Developers Italia</title>
-              <meta http-equiv="refresh" content="0; URL=https://join.slack.com/t/developersitalia/shared_invite/$TOKEN">
+              <meta http-equiv="refresh" content="0; URL=$INVITE_URL">
             </head>
           </html>
           EOF
         env:
-          TOKEN: ${{ inputs.token }}
+          INVITE_URL: ${{ inputs.token }}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "chore: update Slack token"


### PR DESCRIPTION
Get the whole URL so that users can just copy and paste it from the Slack UI